### PR TITLE
[MSN-335] Check folder instead of just folder name in path

### DIFF
--- a/main.py
+++ b/main.py
@@ -101,25 +101,25 @@ def create_product_from_file_path(file_path: str) -> Product:
         timezone.utc
     )
 
-    if "images" in file_path:
-        if "EO" in file_path:
+    if "images/" in file_path:
+        if "EO/" in file_path:
             product = Product("image", "EO", last_modified_on)
-        if "HS" in file_path:
+        if "HS/" in file_path:
             product = Product("image", "HS", last_modified_on)
-        if "IR" in file_path:
+        if "IR/" in file_path:
             product = Product("image", "IR", last_modified_on)
-    elif "tactical" in file_path:
-        if "Detection" in file_path:
+    elif "tactical/" in file_path:
+        if "Detection/" in file_path:
             product = Product("tactical", "Detection", last_modified_on)
-        if "HeatPerimeter" in file_path:
+        if "HeatPerimeter/" in file_path:
             product = Product("tactical", "HeatPerimeter", last_modified_on)
-        if "IntenseHeat" in file_path:
+        if "IntenseHeat/" in file_path:
             product = Product("tactical", "IntenseHeat", last_modified_on)
-        if "IsolatedHeat" in file_path:
+        if "IsolatedHeat/" in file_path:
             product = Product("tactical", "IsolatedHeat", last_modified_on)
-        if "ScatteredHeat" in file_path:
+        if "ScatteredHeat/" in file_path:
             product = Product("tactical", "ScatteredHeat", last_modified_on)
-    elif "videos" in file_path:
+    elif "videos/" in file_path:
         product = Product("video", None, last_modified_on)
 
     if product is None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -43,6 +43,21 @@ class TestMain(unittest.TestCase):
         mock_getmtime.assert_called_once_with(file_path)
 
     @patch("os.path.getmtime", return_value=1234567890.0)
+    def test_create_product_from_file_path_image_with_wrong_type_in_path(
+        self, mock_getmtime
+    ):
+        file_path = "images/EO/IRimage.tif"
+        expected_product = Product(
+            "image", "EO", datetime.fromtimestamp(1234567890.0, tz=timezone.utc)
+        )
+        created_product = create_product_from_file_path(file_path)
+        print(created_product)
+        print(expected_product)
+        self.assertEqual(created_product, expected_product)
+
+        mock_getmtime.assert_called_once_with(file_path)
+
+    @patch("os.path.getmtime", return_value=1234567890.0)
     def test_create_product_from_file_path_tactical(self, mock_getmtime):
         file_path = "tactical/Detection/some_detection.kml"
         expected_product = Product(


### PR DESCRIPTION
## Ticket

[MSN-335](https://intterragroup.atlassian.net/browse/MSN-335)

## Background

We received a bug report for images being uploaded with the wrong type ie. EO images being uploaded as IR. After working with Jim, we determined that if the file contained the type we were searching on in it's name, we would match on that instead of the folder structure. Now we look for the directory in the path instead of just the directory name ie. `EO vs EO/`

## Code Review

### Points of Focus

- Method for determining path name
- Test case created for this

### Test Plan

- Run DSA with local storage mode
- Upload a file with IR in it's name to the images/EO folder
- Text output should show EOimage in the name instead of IRimage


[MSN-335]: https://intterragroup.atlassian.net/browse/MSN-335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ