### PR TITLE
Fix bug with windows directory slash direction

### DIFF
--- a/main.py
+++ b/main.py
@@ -101,25 +101,29 @@ def create_product_from_file_path(file_path: str) -> Product:
         timezone.utc
     )
 
-    if "images/" in file_path:
-        if "EO/" in file_path:
+    folders_in_path = file_path.split(os.path.sep)
+    # We only want to check the mission path, without filename and user's path
+    mission_path = folders_in_path[folders_in_path.index("missions") + 2 : -1]
+
+    if "images" in mission_path:
+        if "EO" in mission_path:
             product = Product("image", "EO", last_modified_on)
-        if "HS/" in file_path:
+        if "HS" in mission_path:
             product = Product("image", "HS", last_modified_on)
-        if "IR/" in file_path:
+        if "IR" in mission_path:
             product = Product("image", "IR", last_modified_on)
-    elif "tactical/" in file_path:
-        if "Detection/" in file_path:
+    elif "tactical" in mission_path:
+        if "Detection" in mission_path:
             product = Product("tactical", "Detection", last_modified_on)
-        if "HeatPerimeter/" in file_path:
+        if "HeatPerimeter" in mission_path:
             product = Product("tactical", "HeatPerimeter", last_modified_on)
-        if "IntenseHeat/" in file_path:
+        if "IntenseHeat" in mission_path:
             product = Product("tactical", "IntenseHeat", last_modified_on)
-        if "IsolatedHeat/" in file_path:
+        if "IsolatedHeat" in mission_path:
             product = Product("tactical", "IsolatedHeat", last_modified_on)
-        if "ScatteredHeat/" in file_path:
+        if "ScatteredHeat" in mission_path:
             product = Product("tactical", "ScatteredHeat", last_modified_on)
-    elif "videos/" in file_path:
+    elif "videos" in mission_path:
         product = Product("video", None, last_modified_on)
 
     if product is None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -31,7 +31,7 @@ class TestMain(unittest.TestCase):
 
     @patch("os.path.getmtime", return_value=1234567890.0)
     def test_create_product_from_file_path_image(self, mock_getmtime):
-        file_path = "images/EO/some_image.tif"
+        file_path = "missions/name/images/EO/some_image.tif"
         expected_product = Product(
             "image", "EO", datetime.fromtimestamp(1234567890.0, tz=timezone.utc)
         )
@@ -46,7 +46,7 @@ class TestMain(unittest.TestCase):
     def test_create_product_from_file_path_image_with_wrong_type_in_path(
         self, mock_getmtime
     ):
-        file_path = "images/EO/IRimage.tif"
+        file_path = "missions/name/images/EO/IRimage.tif"
         expected_product = Product(
             "image", "EO", datetime.fromtimestamp(1234567890.0, tz=timezone.utc)
         )
@@ -59,7 +59,7 @@ class TestMain(unittest.TestCase):
 
     @patch("os.path.getmtime", return_value=1234567890.0)
     def test_create_product_from_file_path_tactical(self, mock_getmtime):
-        file_path = "tactical/Detection/some_detection.kml"
+        file_path = "missions/name/tactical/Detection/some_detection.kml"
         expected_product = Product(
             "tactical",
             "Detection",
@@ -72,7 +72,7 @@ class TestMain(unittest.TestCase):
 
     @patch("os.path.getmtime", return_value=1234567890.0)
     def test_create_product_from_file_path_video(self, mock_getmtime):
-        file_path = "videos/some_video.ts"
+        file_path = "missions/name/videos/some_video.ts"
         expected_product = Product(
             "video", None, datetime.fromtimestamp(1234567890.0, tz=timezone.utc)
         )
@@ -83,7 +83,7 @@ class TestMain(unittest.TestCase):
 
     @patch("os.path.getmtime", return_value=1234567890.0)
     def test_create_product_from_file_path_invalid(self, mock_getmtime):
-        file_path = "invalid_path/some_file.txt"
+        file_path = "missions/name/invalid_path/some_file.txt"
         with self.assertRaises(ValueError):
             create_product_from_file_path(file_path)
 


### PR DESCRIPTION
Failed to account for windows path having a backslash instead of a forward slash. To fix this, I am now splitting the path using the OS path separator and also removing the filename from the path to prevent the original bug this was intended to fix (product type being in the path)
